### PR TITLE
Update the way to hide frame

### DIFF
--- a/sounds.pde
+++ b/sounds.pde
@@ -11,7 +11,7 @@ int time;
 SinOsc[] oscillators;
 
 void setup() {
-  frame.setVisible(false);
+  surface.setVisible(false);
   img = loadImage("test.png");
   img.resize(0, resolution);
   img.loadPixels();


### PR DESCRIPTION
I run the program in the latest Processing and get this message: `Use surface.setVisible() instead of frame.setVisible in Processing 3`.

Link: [surface.setVisible()](https://github.com/processing/processing/blob/4bb41d9851f24584c064d75e759e6ac3b0f65928/core/src/processing/awt/PSurfaceAWT.java#L686).